### PR TITLE
fix(frontend/copilot): send question answers right away and advance on option pick

### DIFF
--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/ChainActionCard.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/ChainActionCard.tsx
@@ -31,8 +31,8 @@ interface Props {
 
 /** Everything the chain still needs from the user, stacked below it as one
  *  card per kind of ask — connectors, run inputs, questions. The questions
- *  card carries its own Skip/Add footer (Add drafts the combined reply into
- *  the chat input); an inputs-only stack falls back to a lone Proceed, and
+ *  card carries its own Skip/Send footer (Send posts the combined reply as
+ *  one message); an inputs-only stack falls back to a lone Proceed, and
  *  a connectors-only card has no button: connecting is the whole ask. */
 export function ChainActionCard({
   connectors,

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/QuestionAnswerField.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/QuestionAnswerField.tsx
@@ -13,6 +13,9 @@ interface Props {
   labelId: string;
   autoFocus: boolean;
   onChange: (value: string) => void;
+  /** Only the option list can fire this — free text has no single moment
+   *  where the answer is done. */
+  onPick: (value: string) => void;
   onSubmit: () => void;
 }
 
@@ -27,6 +30,7 @@ export function QuestionAnswerField({
   labelId,
   autoFocus,
   onChange,
+  onPick,
   onSubmit,
 }: Props) {
   const options = question.options ?? [];
@@ -89,6 +93,7 @@ export function QuestionAnswerField({
         labelId={labelId}
         focusActiveOption={autoFocus || toggled}
         onChange={onChange}
+        onPick={onPick}
         onSubmit={onSubmit}
       />
       <button

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/QuestionOptionList.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/QuestionOptionList.tsx
@@ -13,6 +13,9 @@ interface Props {
   labelId: string;
   focusActiveOption: boolean;
   onChange: (value: string) => void;
+  /** A pointer or tap choice, as opposed to `onChange`, which the arrow keys
+   *  fire too while the user is only browsing the group. */
+  onPick: (value: string) => void;
   onSubmit: () => void;
 }
 
@@ -25,6 +28,7 @@ export function QuestionOptionList({
   labelId,
   focusActiveOption,
   onChange,
+  onPick,
   onSubmit,
 }: Props) {
   const refs = useRef<(HTMLButtonElement | null)[]>([]);
@@ -80,7 +84,7 @@ export function QuestionOptionList({
             role="radio"
             aria-checked={isSelected}
             tabIndex={index === active ? 0 : -1}
-            onClick={() => onChange(option)}
+            onClick={() => onPick(option)}
             onKeyDown={(event) => handleKeyDown(event, index)}
             className={
               "flex items-center justify-between gap-2 rounded-2xl px-3 py-2 text-left text-sm leading-relaxed transition-all " +

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/QuestionOptionList.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/QuestionOptionList.tsx
@@ -49,10 +49,17 @@ export function QuestionOptionList({
     // tabbing past the pager to reach send. Selecting first means tabbing in
     // and hitting Enter can't submit an option nobody chose — and arrowing or
     // clicking already selects, so those reach the pager on the first Enter.
+    // Space reaches the native button's click the same way, so it only selects,
+    // like the arrows do, leaving a pointer click the one thing that advances.
     if (isKey(event, "Enter")) {
       event.preventDefault();
       if (options[index] === value.trim()) onSubmit();
       else onChange(options[index]);
+      return;
+    }
+    if (isKey(event, " ")) {
+      event.preventDefault();
+      onChange(options[index]);
       return;
     }
     const step = isKey(event, "ArrowDown", "ArrowRight")

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/QuestionsSection.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/QuestionsSection.tsx
@@ -18,9 +18,9 @@ interface Props {
   onProceed: () => void;
 }
 
-/** One question per step. The footer pager (chevrons + ring dots) moves
- *  between questions; the round action button advances and, on the last
- *  step, sends every answer as one message. */
+/** One question per step. Picking an option advances on its own; the footer
+ *  pager (chevrons + ring dots) moves between questions, and the round action
+ *  button advances and, on the last step, sends every answer as one message. */
 export function QuestionsSection({ requests, isReady, onProceed }: Props) {
   const [step, setStep] = useState(0);
   const sectionId = useId();
@@ -47,6 +47,13 @@ export function QuestionsSection({ requests, isReady, onProceed }: Props) {
     } else if (answered) {
       setStep(current + 1);
     }
+  }
+
+  // A tap on an option is the whole answer, so the pager moves on by itself;
+  // the last question keeps the send button as its explicit final step.
+  function handlePick(value: string) {
+    request.onAnswer(question.keyword, value);
+    if (!isLast) setStep(current + 1);
   }
 
   return (
@@ -87,6 +94,7 @@ export function QuestionsSection({ requests, isReady, onProceed }: Props) {
           labelId={labelId}
           autoFocus={current > 0}
           onChange={(value) => request.onAnswer(question.keyword, value)}
+          onPick={handlePick}
           onSubmit={handleAction}
         />
       </m.div>

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/QuestionsSection.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/QuestionsSection.tsx
@@ -20,7 +20,7 @@ interface Props {
 
 /** One question per step. The footer pager (chevrons + ring dots) moves
  *  between questions; the round action button advances and, on the last
- *  step, drafts every answer into the chat input. */
+ *  step, sends every answer as one message. */
 export function QuestionsSection({ requests, isReady, onProceed }: Props) {
   const [step, setStep] = useState(0);
   const sectionId = useId();
@@ -134,7 +134,7 @@ export function QuestionsSection({ requests, isReady, onProceed }: Props) {
 
         <button
           type="button"
-          aria-label={isLast ? "Add answers to message" : "Next question"}
+          aria-label={isLast ? "Send answers" : "Next question"}
           disabled={!actionEnabled}
           onClick={handleAction}
           className={

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/__tests__/ChainActionCard.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/__tests__/ChainActionCard.test.tsx
@@ -635,7 +635,7 @@ describe("ChainActionCard", () => {
       renderCard({ questions: [questionRequest()] });
 
       const send = screen.getByRole("button", {
-        name: "Add answers to message",
+        name: "Send answers",
       }) as HTMLButtonElement;
       expect(send.disabled).toBe(true);
     });
@@ -645,9 +645,7 @@ describe("ChainActionCard", () => {
         questions: [questionRequest({ answers: { region: "Europe" } })],
       });
 
-      fireEvent.click(
-        screen.getByRole("button", { name: "Add answers to message" }),
-      );
+      fireEvent.click(screen.getByRole("button", { name: "Send answers" }));
       expect(onProceed).toHaveBeenCalledOnce();
     });
 
@@ -1110,7 +1108,7 @@ describe("ChainActionCard", () => {
       expect(
         (
           screen.getByRole("button", {
-            name: "Add answers to message",
+            name: "Send answers",
           }) as HTMLButtonElement
         ).disabled,
       ).toBe(true);
@@ -1131,7 +1129,7 @@ describe("ChainActionCard", () => {
       );
 
       const send = screen.getByRole("button", {
-        name: "Add answers to message",
+        name: "Send answers",
       }) as HTMLButtonElement;
       expect(send.disabled).toBe(false);
       fireEvent.click(send);
@@ -1179,9 +1177,7 @@ describe("ChainActionCard", () => {
         isReady: false,
       });
 
-      fireEvent.click(
-        screen.getByRole("button", { name: "Add answers to message" }),
-      );
+      fireEvent.click(screen.getByRole("button", { name: "Send answers" }));
       expect(onProceed).toHaveBeenCalledOnce();
     });
   });

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/__tests__/ChainActionCard.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/__tests__/ChainActionCard.test.tsx
@@ -1136,6 +1136,83 @@ describe("ChainActionCard", () => {
       expect(onProceed).toHaveBeenCalledOnce();
     });
 
+    it("advances to the next question when an option is clicked", () => {
+      const request = questionRequest({
+        questions: [
+          {
+            question: "Which region?",
+            keyword: "region",
+            options: ["Europe", "Americas"],
+          },
+          { question: "Which format?", keyword: "format" },
+        ],
+      });
+      renderCard({ questions: [request] });
+
+      fireEvent.click(screen.getByRole("radio", { name: "Europe" }));
+      expect(request.onAnswer).toHaveBeenCalledWith("region", "Europe");
+      expect(screen.getByText("Which format?")).toBeDefined();
+    });
+
+    it("stays on the last question after an option is clicked", () => {
+      const request = questionRequest({
+        questions: [
+          {
+            question: "Which region?",
+            keyword: "region",
+            options: ["Europe", "Americas"],
+          },
+        ],
+      });
+      const { onProceed, rerender } = renderCard({ questions: [request] });
+
+      fireEvent.click(screen.getByRole("radio", { name: "Europe" }));
+      expect(request.onAnswer).toHaveBeenCalledWith("region", "Europe");
+      expect(screen.getByText("Which region?")).toBeDefined();
+      expect(onProceed).not.toHaveBeenCalled();
+
+      rerender(
+        <ChainActionCard
+          connectors={[]}
+          mcp={[]}
+          inputs={[]}
+          questions={[{ ...request, answers: { region: "Europe" } }]}
+          manualProceed={false}
+          isReady
+          onProceed={onProceed}
+        />,
+      );
+
+      expect(
+        (
+          screen.getByRole("button", {
+            name: "Send answers",
+          }) as HTMLButtonElement
+        ).disabled,
+      ).toBe(false);
+    });
+
+    it("does not advance when the arrow keys select an option", () => {
+      const request = questionRequest({
+        questions: [
+          {
+            question: "Which region?",
+            keyword: "region",
+            options: ["Europe", "Americas"],
+          },
+          { question: "Which format?", keyword: "format" },
+        ],
+      });
+      renderCard({ questions: [request] });
+
+      const europe = screen.getByRole("radio", { name: "Europe" });
+      europe.focus();
+      fireEvent.keyDown(europe, { key: "ArrowDown" });
+
+      expect(request.onAnswer).toHaveBeenCalledWith("region", "Americas");
+      expect(screen.getByText("Which region?")).toBeDefined();
+    });
+
     it("keeps two same-keyword questions on their own cards", () => {
       // Keywords are unique only within a request, so the pager keys on
       // position — sharing an id would stop the field remounting, leaving the

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/__tests__/ChainActionCard.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/__tests__/ChainActionCard.test.tsx
@@ -1213,6 +1213,27 @@ describe("ChainActionCard", () => {
       expect(screen.getByText("Which region?")).toBeDefined();
     });
 
+    it("selects without advancing when Space is pressed on an option", () => {
+      const request = questionRequest({
+        questions: [
+          {
+            question: "Which region?",
+            keyword: "region",
+            options: ["Europe", "Americas"],
+          },
+          { question: "Which format?", keyword: "format" },
+        ],
+      });
+      renderCard({ questions: [request] });
+
+      const europe = screen.getByRole("radio", { name: "Europe" });
+      europe.focus();
+      fireEvent.keyDown(europe, { key: " " });
+
+      expect(request.onAnswer).toHaveBeenCalledWith("region", "Europe");
+      expect(screen.getByText("Which region?")).toBeDefined();
+    });
+
     it("keeps two same-keyword questions on their own cards", () => {
       // Keywords are unique only within a request, so the pager keys on
       // position — sharing an id would stop the field remounting, leaving the

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/__tests__/QuestionAnswerField.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChainActionCard/__tests__/QuestionAnswerField.test.tsx
@@ -11,6 +11,7 @@ function renderField(value = "ねこ") {
       labelId="label-1"
       autoFocus={false}
       onChange={() => {}}
+      onPick={() => {}}
       onSubmit={onSubmit}
     />,
   );

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/helpers.ts
@@ -44,11 +44,12 @@ export const COMPACT_SEND_BUTTON_CLASS =
 export const CARD_SEND_BUTTON_CLASS =
   "size-9 rounded-full border-transparent bg-zinc-950 text-white transition-[background-color,transform] hover:border-transparent hover:bg-zinc-800 active:scale-[0.98] disabled:border-transparent disabled:bg-zinc-950/[0.06] disabled:text-zinc-400";
 
-/** Shared with the chain's cards: every path that sends a message reports a
- *  rejection the same way. */
-export function describeSendFailure(error: unknown) {
+/** Shared by every path that sends a message. `recovery` is the lowercase
+ *  clause telling the user where their text went, e.g. "your message is
+ *  back in the composer". */
+export function describeSendFailure(error: unknown, recovery: string) {
   const reason = error instanceof Error ? error.message.trim() : "";
   return reason
-    ? `${reason} — your message is back in the composer.`
-    : "Your message is back in the composer. Try again.";
+    ? `${reason} — ${recovery}.`
+    : `${recovery.charAt(0).toUpperCase()}${recovery.slice(1)}. Try again.`;
 }

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/helpers.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/helpers.ts
@@ -43,3 +43,12 @@ export const COMPACT_SEND_BUTTON_CLASS =
 
 export const CARD_SEND_BUTTON_CLASS =
   "size-9 rounded-full border-transparent bg-zinc-950 text-white transition-[background-color,transform] hover:border-transparent hover:bg-zinc-800 active:scale-[0.98] disabled:border-transparent disabled:bg-zinc-950/[0.06] disabled:text-zinc-400";
+
+/** Shared with the chain's cards: every path that sends a message reports a
+ *  rejection the same way. */
+export function describeSendFailure(error: unknown) {
+  const reason = error instanceof Error ? error.message.trim() : "";
+  return reason
+    ? `${reason} — your message is back in the composer.`
+    : "Your message is back in the composer. Try again.";
+}

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/useChatInput.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/useChatInput.ts
@@ -1,4 +1,5 @@
 import { useCopilotUIStore } from "@/app/(platform)/copilot/store";
+import { describeSendFailure } from "./helpers";
 import { toast } from "@/components/molecules/Toast/use-toast";
 import { ChangeEvent, FormEvent, useEffect, useRef, useState } from "react";
 
@@ -114,11 +115,4 @@ export function useChatInput({
 function restoreFailedDraft(current: string, failed: string) {
   if (!current.trim() || current === failed) return failed;
   return `${failed}\n\n${current}`;
-}
-
-function describeSendFailure(error: unknown) {
-  const reason = error instanceof Error ? error.message.trim() : "";
-  return reason
-    ? `${reason} — your message is back in the composer.`
-    : "Your message is back in the composer. Try again.";
 }

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/useChatInput.ts
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ChatInput/useChatInput.ts
@@ -78,7 +78,10 @@ export function useChatInput({
       setValue((current) => restoreFailedDraft(current, message));
       toast({
         title: "Couldn't send message",
-        description: describeSendFailure(error),
+        description: describeSendFailure(
+          error,
+          "your message is back in the composer",
+        ),
         variant: "destructive",
       });
     } finally {

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ExpertCards.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ExpertCards.tsx
@@ -17,10 +17,12 @@ import { Button } from "@/components/atoms/Button/Button";
 import { Icon } from "@/components/atoms/Icon/Icon";
 import { Skeleton } from "@/components/atoms/Skeleton/Skeleton";
 import { ExpertAvatar } from "@/components/molecules/ExpertAvatar/ExpertAvatar";
+import { toast } from "@/components/molecules/Toast/use-toast";
 import { cn } from "@/lib/utils";
 import { Flag, useGetFlag } from "@/services/feature-flags/use-get-flag";
 import { GenericTool } from "../../tools/GenericTool/GenericTool";
 import { type ArtifactRef, useCopilotUIStore } from "../../store";
+import { describeSendFailure } from "../ChatInput/helpers";
 import { CopilotChatActionsContext } from "../CopilotChatActionsProvider/useCopilotChatActions";
 import { asObject, str } from "./resultHelpers";
 
@@ -456,7 +458,18 @@ export function ExpertChangeGroup({
     const message = proposals
       .map((proposal) => decisionLine(proposal, decisions[proposal.toolCallId]))
       .join("\n");
-    void actions.onSend(message);
+    // The card stays marked sent because the message is already in the
+    // thread for Retry — the failure only needs saying.
+    void Promise.resolve(actions.onSend(message)).catch((error: unknown) =>
+      toast({
+        title: "Couldn't send message",
+        description: describeSendFailure(
+          error,
+          "it is still in the thread, use Retry to send it again",
+        ),
+        variant: "destructive",
+      }),
+    );
     setSent(true);
   }
 

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ExpertCards.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ExpertCards.tsx
@@ -5,13 +5,14 @@ import {
   ArrowRight01Icon,
   InformationCircleIcon,
   PencilEdit02Icon,
+  SentIcon,
   UndoIcon,
   Tick02Icon,
   UserAdd01Icon,
 } from "@hugeicons/core-free-icons";
 import type { IconSvgElement } from "@hugeicons/react";
 import type { ToolUIPart } from "ai";
-import { type ReactNode, useContext, useState } from "react";
+import { type ReactNode, useState } from "react";
 import { Button } from "@/components/atoms/Button/Button";
 import { Icon } from "@/components/atoms/Icon/Icon";
 import { Skeleton } from "@/components/atoms/Skeleton/Skeleton";
@@ -20,7 +21,6 @@ import { cn } from "@/lib/utils";
 import { Flag, useGetFlag } from "@/services/feature-flags/use-get-flag";
 import { GenericTool } from "../../tools/GenericTool/GenericTool";
 import { type ArtifactRef, useCopilotUIStore } from "../../store";
-import { CopilotChatActionsContext } from "../CopilotChatActionsProvider/useCopilotChatActions";
 import { asObject, str } from "./resultHelpers";
 
 interface Props {
@@ -37,7 +37,7 @@ interface Props {
   onDecide?: (decision: Decision) => void;
   /** Takes the decision back so Approve/Decline can be chosen again. */
   onUndo?: () => void;
-  /** Footer note the group adds once the decisions have been sent. */
+  /** Footer control the group adds once every proposal is decided. */
   action?: ReactNode;
   /** Which way the pager just moved — the identity block slides in from
    *  that side while the shell (Details, pager, decision) stays put. */
@@ -402,9 +402,9 @@ interface GroupProps {
 
 /** One hire/raise per call, so a new team lands as several cards in a
  *  row. They page like the clarifying questions do, one expert at a time:
- *  each Approve/Decline moves to the next, and the last decision sends
- *  every decision line as one message. A decision can be taken back only
- *  up to that point. */
+ *  each Approve/Decline moves to the next, and once every proposal has an
+ *  answer a single send drafts all of them into the composer — the user
+ *  still reads and sends the message themselves. */
 export function ExpertChangeGroup({
   parts,
   isCurrentlyStreaming = false,
@@ -413,8 +413,8 @@ export function ExpertChangeGroup({
   const [step, setStep] = useState(0);
   const [direction, setDirection] = useState<StepDirection | undefined>();
   const [decisions, setDecisions] = useState<Record<string, Decision>>({});
-  const [sent, setSent] = useState(false);
-  const actions = useContext(CopilotChatActionsContext);
+  const [drafted, setDrafted] = useState(false);
+  const setInitialPrompt = useCopilotUIStore((s) => s.setInitialPrompt);
   const visible = parts.filter((part) =>
     isVisibleExpertPart(part, isCurrentlyStreaming),
   );
@@ -426,6 +426,9 @@ export function ExpertChangeGroup({
   const proposals = visible
     .map(proposalOf)
     .filter((proposal): proposal is Proposal => proposal !== null);
+  const allDecided =
+    proposals.length > 0 &&
+    proposals.every((proposal) => decisions[proposal.toolCallId]);
   const currentProposal = readOnly ? null : proposalOf(part);
 
   function goTo(next: number) {
@@ -434,13 +437,8 @@ export function ExpertChangeGroup({
   }
 
   function decide(decision: Decision) {
-    if (!currentProposal || sent) return;
-    const next = { ...decisions, [currentProposal.toolCallId]: decision };
-    setDecisions(next);
-    if (proposals.every((proposal) => next[proposal.toolCallId])) {
-      send(next);
-      return;
-    }
+    if (!currentProposal) return;
+    setDecisions({ ...decisions, [currentProposal.toolCallId]: decision });
     if (!isLast) goTo(current + 1);
   }
 
@@ -448,18 +446,20 @@ export function ExpertChangeGroup({
     if (!currentProposal) return;
     const { [currentProposal.toolCallId]: _, ...rest } = decisions;
     setDecisions(rest);
+    // The draft in the composer no longer matches — offer the send again
+    // once every proposal has an answer.
+    setDrafted(false);
   }
 
-  function send(taken: Record<string, Decision>) {
-    // Outside a chat surface (a preview, say) there is nowhere to send:
-    // the decisions stay recorded and the card never claims it sent them.
-    if (!actions) return;
-    void actions.onSend(
+  function draft() {
+    setInitialPrompt(
       proposals
-        .map((proposal) => decisionLine(proposal, taken[proposal.toolCallId]))
+        .map((proposal) =>
+          decisionLine(proposal, decisions[proposal.toolCallId]),
+        )
         .join("\n"),
     );
-    setSent(true);
+    setDrafted(true);
   }
 
   const pager = visible.length > 1 && (
@@ -511,12 +511,25 @@ export function ExpertChangeGroup({
     </div>
   );
 
-  const action = !readOnly && sent && (
-    <span className="flex items-center gap-1 text-xs text-zinc-400">
-      <Icon icon={Tick02Icon} size={14} />
-      Sent
-    </span>
-  );
+  const action =
+    !readOnly &&
+    allDecided &&
+    (drafted ? (
+      <span className="flex items-center gap-1 text-xs text-zinc-400">
+        <Icon icon={Tick02Icon} size={14} />
+        Added to message
+      </span>
+    ) : (
+      <Button
+        variant="primary"
+        size="icon"
+        aria-label="Add decisions to message"
+        onClick={draft}
+        className="size-8 p-0"
+      >
+        <Icon icon={SentIcon} size={15} />
+      </Button>
+    ));
 
   // The shell (Details, pager, decision buttons) is the same from one
   // expert to the next, so it stays mounted; only the identity block
@@ -528,8 +541,8 @@ export function ExpertChangeGroup({
         isCurrentlyStreaming={isCurrentlyStreaming}
         pager={pager || undefined}
         decision={decisions[part.toolCallId] ?? null}
-        onDecide={currentProposal && !sent ? decide : undefined}
-        onUndo={currentProposal && !sent ? undo : undefined}
+        onDecide={currentProposal ? decide : undefined}
+        onUndo={currentProposal ? undo : undefined}
         action={action || undefined}
         stepDirection={direction}
       />

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ExpertCards.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ExpertCards.tsx
@@ -12,7 +12,7 @@ import {
 } from "@hugeicons/core-free-icons";
 import type { IconSvgElement } from "@hugeicons/react";
 import type { ToolUIPart } from "ai";
-import { type ReactNode, useState } from "react";
+import { type ReactNode, useContext, useState } from "react";
 import { Button } from "@/components/atoms/Button/Button";
 import { Icon } from "@/components/atoms/Icon/Icon";
 import { Skeleton } from "@/components/atoms/Skeleton/Skeleton";
@@ -21,6 +21,7 @@ import { cn } from "@/lib/utils";
 import { Flag, useGetFlag } from "@/services/feature-flags/use-get-flag";
 import { GenericTool } from "../../tools/GenericTool/GenericTool";
 import { type ArtifactRef, useCopilotUIStore } from "../../store";
+import { CopilotChatActionsContext } from "../CopilotChatActionsProvider/useCopilotChatActions";
 import { asObject, str } from "./resultHelpers";
 
 interface Props {
@@ -37,7 +38,8 @@ interface Props {
   onDecide?: (decision: Decision) => void;
   /** Takes the decision back so Approve/Decline can be chosen again. */
   onUndo?: () => void;
-  /** Footer control the group adds once every proposal is decided. */
+  /** Footer control the group adds once every proposal is decided, or
+   *  the sent note after. */
   action?: ReactNode;
   /** Which way the pager just moved — the identity block slides in from
    *  that side while the shell (Details, pager, decision) stays put. */
@@ -403,8 +405,9 @@ interface GroupProps {
 /** One hire/raise per call, so a new team lands as several cards in a
  *  row. They page like the clarifying questions do, one expert at a time:
  *  each Approve/Decline moves to the next, and once every proposal has an
- *  answer a single send drafts all of them into the composer — the user
- *  still reads and sends the message themselves. */
+ *  answer a single send posts all of them as one message — the user no
+ *  longer reviews it in the composer. A decision can be taken back up to
+ *  that point. */
 export function ExpertChangeGroup({
   parts,
   isCurrentlyStreaming = false,
@@ -413,8 +416,8 @@ export function ExpertChangeGroup({
   const [step, setStep] = useState(0);
   const [direction, setDirection] = useState<StepDirection | undefined>();
   const [decisions, setDecisions] = useState<Record<string, Decision>>({});
-  const [drafted, setDrafted] = useState(false);
-  const setInitialPrompt = useCopilotUIStore((s) => s.setInitialPrompt);
+  const [sent, setSent] = useState(false);
+  const actions = useContext(CopilotChatActionsContext);
   const visible = parts.filter((part) =>
     isVisibleExpertPart(part, isCurrentlyStreaming),
   );
@@ -446,20 +449,15 @@ export function ExpertChangeGroup({
     if (!currentProposal) return;
     const { [currentProposal.toolCallId]: _, ...rest } = decisions;
     setDecisions(rest);
-    // The draft in the composer no longer matches — offer the send again
-    // once every proposal has an answer.
-    setDrafted(false);
   }
 
-  function draft() {
-    setInitialPrompt(
-      proposals
-        .map((proposal) =>
-          decisionLine(proposal, decisions[proposal.toolCallId]),
-        )
-        .join("\n"),
-    );
-    setDrafted(true);
+  function send() {
+    if (!actions) return;
+    const message = proposals
+      .map((proposal) => decisionLine(proposal, decisions[proposal.toolCallId]))
+      .join("\n");
+    void actions.onSend(message);
+    setSent(true);
   }
 
   const pager = visible.length > 1 && (
@@ -511,25 +509,25 @@ export function ExpertChangeGroup({
     </div>
   );
 
-  const action =
-    !readOnly &&
-    allDecided &&
-    (drafted ? (
-      <span className="flex items-center gap-1 text-xs text-zinc-400">
-        <Icon icon={Tick02Icon} size={14} />
-        Added to message
-      </span>
-    ) : (
-      <Button
-        variant="primary"
-        size="icon"
-        aria-label="Add decisions to message"
-        onClick={draft}
-        className="size-8 p-0"
-      >
-        <Icon icon={SentIcon} size={15} />
-      </Button>
-    ));
+  // While the turn is still streaming another proposal part can land in
+  // this group, so the send waits for the stream to settle.
+  const canSend = !readOnly && !!actions && allDecided && !isCurrentlyStreaming;
+  const action = sent ? (
+    <span className="flex items-center gap-1 text-xs text-zinc-400">
+      <Icon icon={Tick02Icon} size={14} />
+      Sent
+    </span>
+  ) : canSend ? (
+    <Button
+      variant="primary"
+      size="icon"
+      aria-label="Send decisions"
+      onClick={send}
+      className="size-8 p-0"
+    >
+      <Icon icon={SentIcon} size={15} />
+    </Button>
+  ) : null;
 
   // The shell (Details, pager, decision buttons) is the same from one
   // expert to the next, so it stays mounted; only the identity block
@@ -541,8 +539,8 @@ export function ExpertChangeGroup({
         isCurrentlyStreaming={isCurrentlyStreaming}
         pager={pager || undefined}
         decision={decisions[part.toolCallId] ?? null}
-        onDecide={currentProposal ? decide : undefined}
-        onUndo={currentProposal ? undo : undefined}
+        onDecide={currentProposal && !sent ? decide : undefined}
+        onUndo={currentProposal && !sent ? undo : undefined}
         action={action || undefined}
         stepDirection={direction}
       />

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ExpertCards.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ExpertCards.tsx
@@ -5,14 +5,13 @@ import {
   ArrowRight01Icon,
   InformationCircleIcon,
   PencilEdit02Icon,
-  SentIcon,
   UndoIcon,
   Tick02Icon,
   UserAdd01Icon,
 } from "@hugeicons/core-free-icons";
 import type { IconSvgElement } from "@hugeicons/react";
 import type { ToolUIPart } from "ai";
-import { type ReactNode, useState } from "react";
+import { type ReactNode, useContext, useState } from "react";
 import { Button } from "@/components/atoms/Button/Button";
 import { Icon } from "@/components/atoms/Icon/Icon";
 import { Skeleton } from "@/components/atoms/Skeleton/Skeleton";
@@ -21,6 +20,7 @@ import { cn } from "@/lib/utils";
 import { Flag, useGetFlag } from "@/services/feature-flags/use-get-flag";
 import { GenericTool } from "../../tools/GenericTool/GenericTool";
 import { type ArtifactRef, useCopilotUIStore } from "../../store";
+import { CopilotChatActionsContext } from "../CopilotChatActionsProvider/useCopilotChatActions";
 import { asObject, str } from "./resultHelpers";
 
 interface Props {
@@ -37,7 +37,7 @@ interface Props {
   onDecide?: (decision: Decision) => void;
   /** Takes the decision back so Approve/Decline can be chosen again. */
   onUndo?: () => void;
-  /** Footer control the group adds once every proposal is decided. */
+  /** Footer note the group adds once the decisions have been sent. */
   action?: ReactNode;
   /** Which way the pager just moved — the identity block slides in from
    *  that side while the shell (Details, pager, decision) stays put. */
@@ -402,9 +402,9 @@ interface GroupProps {
 
 /** One hire/raise per call, so a new team lands as several cards in a
  *  row. They page like the clarifying questions do, one expert at a time:
- *  each Approve/Decline moves to the next, and once every proposal has an
- *  answer a single send drafts all of them into the composer — the user
- *  still reads and sends the message themselves. */
+ *  each Approve/Decline moves to the next, and the last decision sends
+ *  every decision line as one message. A decision can be taken back only
+ *  up to that point. */
 export function ExpertChangeGroup({
   parts,
   isCurrentlyStreaming = false,
@@ -413,8 +413,8 @@ export function ExpertChangeGroup({
   const [step, setStep] = useState(0);
   const [direction, setDirection] = useState<StepDirection | undefined>();
   const [decisions, setDecisions] = useState<Record<string, Decision>>({});
-  const [drafted, setDrafted] = useState(false);
-  const setInitialPrompt = useCopilotUIStore((s) => s.setInitialPrompt);
+  const [sent, setSent] = useState(false);
+  const actions = useContext(CopilotChatActionsContext);
   const visible = parts.filter((part) =>
     isVisibleExpertPart(part, isCurrentlyStreaming),
   );
@@ -426,9 +426,6 @@ export function ExpertChangeGroup({
   const proposals = visible
     .map(proposalOf)
     .filter((proposal): proposal is Proposal => proposal !== null);
-  const allDecided =
-    proposals.length > 0 &&
-    proposals.every((proposal) => decisions[proposal.toolCallId]);
   const currentProposal = readOnly ? null : proposalOf(part);
 
   function goTo(next: number) {
@@ -437,8 +434,13 @@ export function ExpertChangeGroup({
   }
 
   function decide(decision: Decision) {
-    if (!currentProposal) return;
-    setDecisions({ ...decisions, [currentProposal.toolCallId]: decision });
+    if (!currentProposal || sent) return;
+    const next = { ...decisions, [currentProposal.toolCallId]: decision };
+    setDecisions(next);
+    if (proposals.every((proposal) => next[proposal.toolCallId])) {
+      send(next);
+      return;
+    }
     if (!isLast) goTo(current + 1);
   }
 
@@ -446,20 +448,18 @@ export function ExpertChangeGroup({
     if (!currentProposal) return;
     const { [currentProposal.toolCallId]: _, ...rest } = decisions;
     setDecisions(rest);
-    // The draft in the composer no longer matches — offer the send again
-    // once every proposal has an answer.
-    setDrafted(false);
   }
 
-  function draft() {
-    setInitialPrompt(
+  function send(taken: Record<string, Decision>) {
+    // Outside a chat surface (a preview, say) there is nowhere to send:
+    // the decisions stay recorded and the card never claims it sent them.
+    if (!actions) return;
+    void actions.onSend(
       proposals
-        .map((proposal) =>
-          decisionLine(proposal, decisions[proposal.toolCallId]),
-        )
+        .map((proposal) => decisionLine(proposal, taken[proposal.toolCallId]))
         .join("\n"),
     );
-    setDrafted(true);
+    setSent(true);
   }
 
   const pager = visible.length > 1 && (
@@ -511,25 +511,12 @@ export function ExpertChangeGroup({
     </div>
   );
 
-  const action =
-    !readOnly &&
-    allDecided &&
-    (drafted ? (
-      <span className="flex items-center gap-1 text-xs text-zinc-400">
-        <Icon icon={Tick02Icon} size={14} />
-        Added to message
-      </span>
-    ) : (
-      <Button
-        variant="primary"
-        size="icon"
-        aria-label="Add decisions to message"
-        onClick={draft}
-        className="size-8 p-0"
-      >
-        <Icon icon={SentIcon} size={15} />
-      </Button>
-    ));
+  const action = !readOnly && sent && (
+    <span className="flex items-center gap-1 text-xs text-zinc-400">
+      <Icon icon={Tick02Icon} size={14} />
+      Sent
+    </span>
+  );
 
   // The shell (Details, pager, decision buttons) is the same from one
   // expert to the next, so it stays mounted; only the identity block
@@ -541,8 +528,8 @@ export function ExpertChangeGroup({
         isCurrentlyStreaming={isCurrentlyStreaming}
         pager={pager || undefined}
         decision={decisions[part.toolCallId] ?? null}
-        onDecide={currentProposal ? decide : undefined}
-        onUndo={currentProposal ? undo : undefined}
+        onDecide={currentProposal && !sent ? decide : undefined}
+        onUndo={currentProposal && !sent ? undo : undefined}
         action={action || undefined}
         stepDirection={direction}
       />

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ToolChain.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ToolChain.tsx
@@ -23,6 +23,8 @@ import {
 } from "react";
 import { Button } from "@/components/atoms/Button/Button";
 import { Icon } from "@/components/atoms/Icon/Icon";
+import { toast } from "@/components/molecules/Toast/use-toast";
+import { describeSendFailure } from "../ChatInput/helpers";
 import { useCopilotChatActions } from "../CopilotChatActionsProvider/useCopilotChatActions";
 import { ChainActionCard } from "../ChainActionCard/ChainActionCard";
 import { PendingQuestionsContext } from "../QuestionDock/PendingQuestionsContext";
@@ -150,7 +152,7 @@ export function ToolChain({ parts, isStreaming, readOnly = false }: Props) {
         .join("\n\n");
       if (!message) return;
       pendingActions.forEach((entry) => entry.onSent?.());
-      void onSend(message);
+      sendReply(message);
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps -- pendingActions is rebuilt every render; the ref makes this once-per-chain
     [canAutoSend],
@@ -210,6 +212,20 @@ export function ToolChain({ parts, isStreaming, readOnly = false }: Props) {
   // still-running chain has no such ending.
   const showDone = !isStreaming && !hasError && !windowMode && panelOpen;
 
+  // The cards are already gone by the time a send can fail — the user's
+  // message is appended optimistically and the chat's error banner offers
+  // Retry — so the failure only needs to be said out loud, like the
+  // composer does.
+  function sendReply(message: string) {
+    void Promise.resolve(onSend(message)).catch((error: unknown) =>
+      toast({
+        title: "Couldn't send message",
+        description: describeSendFailure(error),
+        variant: "destructive",
+      }),
+    );
+  }
+
   // Proceed sends the combined reply of every READY card as one message,
   // and their onSent callbacks fire at that moment. Unready cards (e.g. an
   // unconnected MCP server) are left out instead of blocking the ready ones.
@@ -221,7 +237,7 @@ export function ToolChain({ parts, isStreaming, readOnly = false }: Props) {
       .join("\n\n");
     if (!message) return;
     readyActions.forEach((entry) => entry.onSent?.());
-    void onSend(message);
+    sendReply(message);
   }
 
   return (

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ToolChain.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ToolChain.tsx
@@ -23,7 +23,6 @@ import {
 } from "react";
 import { Button } from "@/components/atoms/Button/Button";
 import { Icon } from "@/components/atoms/Icon/Icon";
-import { useCopilotUIStore } from "@/app/(platform)/copilot/store";
 import { useCopilotChatActions } from "../CopilotChatActionsProvider/useCopilotChatActions";
 import { ChainActionCard } from "../ChainActionCard/ChainActionCard";
 import { PendingQuestionsContext } from "../QuestionDock/PendingQuestionsContext";
@@ -49,8 +48,8 @@ interface Props {
   parts: MessagePart[];
   isStreaming: boolean;
   /** Public share viewer: the chain renders as the owner saw it, but setup
-   *  cards and the Proceed draft are the owner's work — a reader gets no
-   *  Connect prompt and no write into the composer store. */
+   *  cards and Proceed are the owner's work — a reader gets no Connect
+   *  prompt and no way to send a follow-up turn. */
   readOnly?: boolean;
 }
 
@@ -60,20 +59,14 @@ export function ToolChain({ parts, isStreaming, readOnly = false }: Props) {
   const reducedMotion = useReducedMotion();
 
   const pendingQuestions = useContext(PendingQuestionsContext);
-  const setInitialPrompt = useCopilotUIStore((s) => s.setInitialPrompt);
   const { onSend } = useCopilotChatActions();
-  const sentMessageCount = useCopilotUIStore((s) => s.sentMessageCount);
-  // Ids drafted by the last Proceed, plus the send count at that moment.
-  // Proceed only fills the composer, so the cards' onSent callbacks fire
-  // when the user actually sends — not when the draft is written.
-  const draftedRef = useRef<{ ids: string[]; sentAt: number } | null>(null);
   // The ref latches against a double effect run; the state re-renders Proceed.
   const autoSentRef = useRef(false);
   const [autoSent, setAutoSent] = useState(false);
 
   // Action cards (credential setup, clarifying questions) register here
   // instead of rendering their own Proceed/Answer buttons — the chain
-  // renders one Proceed that drafts everything into the chat input at once.
+  // renders one Proceed that sends everything as a single message.
   const [actionEntries, setActionEntries] = useState<
     ReadonlyMap<string, ChainActionEntry>
   >(new Map());
@@ -95,16 +88,6 @@ export function ToolChain({ parts, isStreaming, readOnly = false }: Props) {
   const chainActions = useMemo(
     () => ({ register, unregister }),
     [register, unregister],
-  );
-
-  useEffect(
-    function notifyDraftedCardsOnSend() {
-      const drafted = draftedRef.current;
-      if (!drafted || sentMessageCount <= drafted.sentAt) return;
-      draftedRef.current = null;
-      drafted.ids.forEach((id) => actionEntries.get(id)?.onSent?.());
-    },
-    [sentMessageCount, actionEntries],
   );
 
   const pendingActions = [...actionEntries.values()];
@@ -227,11 +210,9 @@ export function ToolChain({ parts, isStreaming, readOnly = false }: Props) {
   // still-running chain has no such ending.
   const showDone = !isStreaming && !hasError && !windowMode && panelOpen;
 
-  // Proceed never sends: it drafts the combined reply of every READY card
-  // into the chat input so the user reviews/edits and presses send
-  // themselves. Unready cards (e.g. an unconnected MCP server) are left
-  // out instead of blocking the ready ones. Cards stay registered until
-  // the message actually goes out, at which point their onSent fires.
+  // Proceed sends the combined reply of every READY card as one message,
+  // and their onSent callbacks fire at that moment. Unready cards (e.g. an
+  // unconnected MCP server) are left out instead of blocking the ready ones.
   function handleProceed() {
     const readyActions = pendingActions.filter((entry) => entry.ready);
     const message = readyActions
@@ -239,11 +220,8 @@ export function ToolChain({ parts, isStreaming, readOnly = false }: Props) {
       .filter(Boolean)
       .join("\n\n");
     if (!message) return;
-    draftedRef.current = {
-      ids: readyActions.map((entry) => entry.id),
-      sentAt: sentMessageCount,
-    };
-    setInitialPrompt(message);
+    readyActions.forEach((entry) => entry.onSent?.());
+    void onSend(message);
   }
 
   return (
@@ -410,8 +388,8 @@ export function ToolChain({ parts, isStreaming, readOnly = false }: Props) {
             <span className="flex items-center gap-1.5 text-sm text-zinc-600">
               <Icon icon={SentIcon} size={16} className="text-zinc-400" />
               {allActionsReady
-                ? "Everything's filled in — send it to continue"
-                : "Complete the steps above, then send to continue"}
+                ? "Everything's filled in"
+                : "Complete the steps above to continue"}
             </span>
             <Button
               variant="primary"

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ToolChain.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/ToolChain.tsx
@@ -214,13 +214,16 @@ export function ToolChain({ parts, isStreaming, readOnly = false }: Props) {
 
   // The cards are already gone by the time a send can fail — the user's
   // message is appended optimistically and the chat's error banner offers
-  // Retry — so the failure only needs to be said out loud, like the
-  // composer does.
+  // Retry — so the failure only needs to be said out loud, and the toast
+  // points at the thread rather than the composer.
   function sendReply(message: string) {
     void Promise.resolve(onSend(message)).catch((error: unknown) =>
       toast({
         title: "Couldn't send message",
-        description: describeSendFailure(error),
+        description: describeSendFailure(
+          error,
+          "it is still in the thread, use Retry to send it again",
+        ),
         variant: "destructive",
       }),
     );

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/ExpertCards.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/ExpertCards.test.tsx
@@ -1,9 +1,8 @@
 import { cleanup, render, screen } from "@/tests/integrations/test-utils";
 import userEvent from "@testing-library/user-event";
 import type { ToolUIPart } from "ai";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { useCopilotUIStore } from "../../../store";
-import { CopilotChatActionsProvider } from "../../CopilotChatActionsProvider/CopilotChatActionsProvider";
 import {
   ExpertChangeCard,
   ExpertChangeGroup,
@@ -37,6 +36,7 @@ describe("expert change cards", () => {
   afterEach(() => {
     artifactsFlag.enabled = false;
     useCopilotUIStore.getState().resetArtifactPanel();
+    useCopilotUIStore.getState().setInitialPrompt(null);
   });
 
   it("shows who the proposed expert is and nothing else", () => {
@@ -391,28 +391,24 @@ describe("ExpertChangeGroup", () => {
 });
 
 describe("expert approval", () => {
-  const onSend = vi.fn();
-
-  function renderGroup(parts: ToolUIPart[], props?: { readOnly?: boolean }) {
-    return render(
-      <CopilotChatActionsProvider onSend={onSend}>
-        <ExpertChangeGroup parts={parts} {...props} />
-      </CopilotChatActionsProvider>,
-    );
+  function prompt(): string | null {
+    return useCopilotUIStore.getState().initialPrompt;
   }
 
-  beforeEach(() => {
-    onSend.mockClear();
-  });
-
-  it("moves to the next expert on each decision and sends once all are decided", async () => {
+  it("moves to the next expert on each decision, then drafts all of them", async () => {
     const user = userEvent.setup();
-    renderGroup([proposal("Fiona", "a"), proposal("Bhaskar", "b")]);
+    render(
+      <ExpertChangeGroup
+        parts={[proposal("Fiona", "a"), proposal("Bhaskar", "b")]}
+      />,
+    );
 
     expect(screen.getByText("Fiona")).toBeDefined();
+    expect(
+      screen.queryByRole("button", { name: "Add decisions to message" }),
+    ).toBeNull();
 
     await user.click(screen.getByRole("button", { name: "Approve" }));
-    expect(onSend).not.toHaveBeenCalled();
     expect(screen.getByText("Bhaskar")).toBeDefined();
     expect(screen.getByText("2 of 2")).toBeDefined();
     expect(
@@ -420,21 +416,29 @@ describe("expert approval", () => {
     ).toContain("emerald");
 
     await user.click(screen.getByRole("button", { name: "Decline" }));
-    expect(onSend).toHaveBeenCalledTimes(1);
-    expect(onSend).toHaveBeenCalledWith(
-      "Approved: create Fiona (confirmation_id: c-a).\nNot approved: do not create Bhaskar, discard that proposal (confirmation_id: c-b).",
-    );
-    expect(screen.getByText("Sent")).toBeDefined();
+    expect(screen.getByRole("button", { name: "Undo decline" })).toBeDefined();
     expect(
       screen.getByRole("button", { name: "Go to expert 2" }).className,
     ).toContain("red");
     expect(screen.queryByRole("button", { name: "Approve" })).toBeNull();
-    expect(screen.queryByRole("button", { name: "Undo decline" })).toBeNull();
+
+    await user.click(
+      screen.getByRole("button", { name: "Add decisions to message" }),
+    );
+    expect(prompt()).toContain("Approved: create Fiona");
+    expect(prompt()).toContain("c-a");
+    expect(prompt()).toContain("Not approved: do not create Bhaskar");
+    expect(prompt()).toContain("c-b");
+    expect(screen.getByText("Added to message")).toBeDefined();
   });
 
   it("remembers a decision when paging back", async () => {
     const user = userEvent.setup();
-    renderGroup([proposal("Fiona", "a"), proposal("Bhaskar", "b")]);
+    render(
+      <ExpertChangeGroup
+        parts={[proposal("Fiona", "a"), proposal("Bhaskar", "b")]}
+      />,
+    );
 
     await user.click(screen.getByRole("button", { name: "Approve" }));
     await user.click(screen.getByRole("button", { name: "Previous expert" }));
@@ -449,69 +453,71 @@ describe("expert approval", () => {
     ).not.toContain("emerald");
   });
 
-  it("sends a single expert straight after its decision", async () => {
-    const user = userEvent.setup();
-    renderGroup([proposal("Otto", "a")]);
-
-    await user.click(screen.getByRole("button", { name: "Approve" }));
-
-    expect(onSend).toHaveBeenCalledWith(
-      "Approved: create Otto (confirmation_id: c-a).",
-    );
-    expect(screen.getByText("Sent")).toBeDefined();
-  });
-
-  it("sends the verb the proposal actually asks for", async () => {
-    const user = userEvent.setup();
-    renderGroup([
-      expertPart(
-        "output-available",
-        {
-          type: "expert_change_proposed",
-          applied: false,
-          confirmation_id: "c-u",
-          preview: { kind: "update", name: "Otto", role: "Engineer" },
-        },
-        "u",
-      ),
-    ]);
-
-    await user.click(screen.getByRole("button", { name: "Approve" }));
-
-    expect(onSend).toHaveBeenCalledWith(
-      "Approved: update Otto (confirmation_id: c-u).",
-    );
-  });
-
-  it("records decisions without sending when no chat actions provider is mounted", async () => {
+  it("drafts a single expert straight after its decision", async () => {
     const user = userEvent.setup();
     render(<ExpertChangeGroup parts={[proposal("Otto", "a")]} />);
 
     await user.click(screen.getByRole("button", { name: "Approve" }));
+    await user.click(
+      screen.getByRole("button", { name: "Add decisions to message" }),
+    );
 
-    expect(onSend).not.toHaveBeenCalled();
-    expect(screen.queryByText("Sent")).toBeNull();
-    expect(screen.getByRole("button", { name: "Unapprove" })).toBeDefined();
+    expect(prompt()).toBe("Approved: create Otto (confirmation_id: c-a).");
+  });
+
+  it("drafts the verb the proposal actually asks for", async () => {
+    const user = userEvent.setup();
+    render(
+      <ExpertChangeGroup
+        parts={[
+          expertPart(
+            "output-available",
+            {
+              type: "expert_change_proposed",
+              applied: false,
+              confirmation_id: "c-u",
+              preview: { kind: "update", name: "Otto", role: "Engineer" },
+            },
+            "u",
+          ),
+        ]}
+      />,
+    );
+
+    await user.click(screen.getByRole("button", { name: "Approve" }));
+    await user.click(
+      screen.getByRole("button", { name: "Add decisions to message" }),
+    );
+
+    expect(prompt()).toBe("Approved: update Otto (confirmation_id: c-u).");
   });
 
   it("offers no decision once applied or on a read-only transcript", () => {
-    renderGroup([
-      expertPart("output-available", {
-        type: "expert_change_applied",
-        applied: true,
-        kind: "raise",
-        expert: { id: "exp-1", name: "Otto", role: "Inbox triage" },
-      }),
-    ]);
+    render(
+      <ExpertChangeGroup
+        parts={[
+          expertPart("output-available", {
+            type: "expert_change_applied",
+            applied: true,
+            kind: "raise",
+            expert: { id: "exp-1", name: "Otto", role: "Inbox triage" },
+          }),
+        ]}
+      />,
+    );
     expect(screen.queryByRole("button", { name: "Approve" })).toBeNull();
     cleanup();
 
-    renderGroup([proposal("Otto", "a")], { readOnly: true });
+    render(<ExpertChangeGroup parts={[proposal("Otto", "a")]} readOnly />);
     expect(screen.queryByRole("button", { name: "Approve" })).toBeNull();
   });
 
   it("keeps the pager inside the card, beside the decision", () => {
-    renderGroup([proposal("Fiona", "a"), proposal("Bhaskar", "b")]);
+    render(
+      <ExpertChangeGroup
+        parts={[proposal("Fiona", "a"), proposal("Bhaskar", "b")]}
+      />,
+    );
 
     const card = screen.getByText("Fiona").closest(".rounded-3xl");
     expect(card).not.toBeNull();

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/ExpertCards.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/ExpertCards.test.tsx
@@ -1,8 +1,9 @@
 import { cleanup, render, screen } from "@/tests/integrations/test-utils";
 import userEvent from "@testing-library/user-event";
 import type { ToolUIPart } from "ai";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useCopilotUIStore } from "../../../store";
+import { CopilotChatActionsProvider } from "../../CopilotChatActionsProvider/CopilotChatActionsProvider";
 import {
   ExpertChangeCard,
   ExpertChangeGroup,
@@ -36,7 +37,6 @@ describe("expert change cards", () => {
   afterEach(() => {
     artifactsFlag.enabled = false;
     useCopilotUIStore.getState().resetArtifactPanel();
-    useCopilotUIStore.getState().setInitialPrompt(null);
   });
 
   it("shows who the proposed expert is and nothing else", () => {
@@ -391,24 +391,28 @@ describe("ExpertChangeGroup", () => {
 });
 
 describe("expert approval", () => {
-  function prompt(): string | null {
-    return useCopilotUIStore.getState().initialPrompt;
+  const onSend = vi.fn();
+
+  function renderGroup(parts: ToolUIPart[], props?: { readOnly?: boolean }) {
+    return render(
+      <CopilotChatActionsProvider onSend={onSend}>
+        <ExpertChangeGroup parts={parts} {...props} />
+      </CopilotChatActionsProvider>,
+    );
   }
 
-  it("moves to the next expert on each decision, then drafts all of them", async () => {
+  beforeEach(() => {
+    onSend.mockClear();
+  });
+
+  it("moves to the next expert on each decision and sends once all are decided", async () => {
     const user = userEvent.setup();
-    render(
-      <ExpertChangeGroup
-        parts={[proposal("Fiona", "a"), proposal("Bhaskar", "b")]}
-      />,
-    );
+    renderGroup([proposal("Fiona", "a"), proposal("Bhaskar", "b")]);
 
     expect(screen.getByText("Fiona")).toBeDefined();
-    expect(
-      screen.queryByRole("button", { name: "Add decisions to message" }),
-    ).toBeNull();
 
     await user.click(screen.getByRole("button", { name: "Approve" }));
+    expect(onSend).not.toHaveBeenCalled();
     expect(screen.getByText("Bhaskar")).toBeDefined();
     expect(screen.getByText("2 of 2")).toBeDefined();
     expect(
@@ -416,29 +420,21 @@ describe("expert approval", () => {
     ).toContain("emerald");
 
     await user.click(screen.getByRole("button", { name: "Decline" }));
-    expect(screen.getByRole("button", { name: "Undo decline" })).toBeDefined();
+    expect(onSend).toHaveBeenCalledTimes(1);
+    expect(onSend).toHaveBeenCalledWith(
+      "Approved: create Fiona (confirmation_id: c-a).\nNot approved: do not create Bhaskar, discard that proposal (confirmation_id: c-b).",
+    );
+    expect(screen.getByText("Sent")).toBeDefined();
     expect(
       screen.getByRole("button", { name: "Go to expert 2" }).className,
     ).toContain("red");
     expect(screen.queryByRole("button", { name: "Approve" })).toBeNull();
-
-    await user.click(
-      screen.getByRole("button", { name: "Add decisions to message" }),
-    );
-    expect(prompt()).toContain("Approved: create Fiona");
-    expect(prompt()).toContain("c-a");
-    expect(prompt()).toContain("Not approved: do not create Bhaskar");
-    expect(prompt()).toContain("c-b");
-    expect(screen.getByText("Added to message")).toBeDefined();
+    expect(screen.queryByRole("button", { name: "Undo decline" })).toBeNull();
   });
 
   it("remembers a decision when paging back", async () => {
     const user = userEvent.setup();
-    render(
-      <ExpertChangeGroup
-        parts={[proposal("Fiona", "a"), proposal("Bhaskar", "b")]}
-      />,
-    );
+    renderGroup([proposal("Fiona", "a"), proposal("Bhaskar", "b")]);
 
     await user.click(screen.getByRole("button", { name: "Approve" }));
     await user.click(screen.getByRole("button", { name: "Previous expert" }));
@@ -453,71 +449,69 @@ describe("expert approval", () => {
     ).not.toContain("emerald");
   });
 
-  it("drafts a single expert straight after its decision", async () => {
+  it("sends a single expert straight after its decision", async () => {
+    const user = userEvent.setup();
+    renderGroup([proposal("Otto", "a")]);
+
+    await user.click(screen.getByRole("button", { name: "Approve" }));
+
+    expect(onSend).toHaveBeenCalledWith(
+      "Approved: create Otto (confirmation_id: c-a).",
+    );
+    expect(screen.getByText("Sent")).toBeDefined();
+  });
+
+  it("sends the verb the proposal actually asks for", async () => {
+    const user = userEvent.setup();
+    renderGroup([
+      expertPart(
+        "output-available",
+        {
+          type: "expert_change_proposed",
+          applied: false,
+          confirmation_id: "c-u",
+          preview: { kind: "update", name: "Otto", role: "Engineer" },
+        },
+        "u",
+      ),
+    ]);
+
+    await user.click(screen.getByRole("button", { name: "Approve" }));
+
+    expect(onSend).toHaveBeenCalledWith(
+      "Approved: update Otto (confirmation_id: c-u).",
+    );
+  });
+
+  it("records decisions without sending when no chat actions provider is mounted", async () => {
     const user = userEvent.setup();
     render(<ExpertChangeGroup parts={[proposal("Otto", "a")]} />);
 
     await user.click(screen.getByRole("button", { name: "Approve" }));
-    await user.click(
-      screen.getByRole("button", { name: "Add decisions to message" }),
-    );
 
-    expect(prompt()).toBe("Approved: create Otto (confirmation_id: c-a).");
-  });
-
-  it("drafts the verb the proposal actually asks for", async () => {
-    const user = userEvent.setup();
-    render(
-      <ExpertChangeGroup
-        parts={[
-          expertPart(
-            "output-available",
-            {
-              type: "expert_change_proposed",
-              applied: false,
-              confirmation_id: "c-u",
-              preview: { kind: "update", name: "Otto", role: "Engineer" },
-            },
-            "u",
-          ),
-        ]}
-      />,
-    );
-
-    await user.click(screen.getByRole("button", { name: "Approve" }));
-    await user.click(
-      screen.getByRole("button", { name: "Add decisions to message" }),
-    );
-
-    expect(prompt()).toBe("Approved: update Otto (confirmation_id: c-u).");
+    expect(onSend).not.toHaveBeenCalled();
+    expect(screen.queryByText("Sent")).toBeNull();
+    expect(screen.getByRole("button", { name: "Unapprove" })).toBeDefined();
   });
 
   it("offers no decision once applied or on a read-only transcript", () => {
-    render(
-      <ExpertChangeGroup
-        parts={[
-          expertPart("output-available", {
-            type: "expert_change_applied",
-            applied: true,
-            kind: "raise",
-            expert: { id: "exp-1", name: "Otto", role: "Inbox triage" },
-          }),
-        ]}
-      />,
-    );
+    renderGroup([
+      expertPart("output-available", {
+        type: "expert_change_applied",
+        applied: true,
+        kind: "raise",
+        expert: { id: "exp-1", name: "Otto", role: "Inbox triage" },
+      }),
+    ]);
     expect(screen.queryByRole("button", { name: "Approve" })).toBeNull();
     cleanup();
 
-    render(<ExpertChangeGroup parts={[proposal("Otto", "a")]} readOnly />);
+    renderGroup([proposal("Otto", "a")], { readOnly: true });
     expect(screen.queryByRole("button", { name: "Approve" })).toBeNull();
   });
 
   it("keeps the pager inside the card, beside the decision", () => {
-    render(
-      <ExpertChangeGroup
-        parts={[proposal("Fiona", "a"), proposal("Bhaskar", "b")]}
-      />,
-    );
+    renderGroup([proposal("Fiona", "a"), proposal("Bhaskar", "b")]);
 
     const card = screen.getByText("Fiona").closest(".rounded-3xl");
     expect(card).not.toBeNull();

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/ExpertCards.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/ExpertCards.test.tsx
@@ -1,8 +1,9 @@
 import { cleanup, render, screen } from "@/tests/integrations/test-utils";
 import userEvent from "@testing-library/user-event";
 import type { ToolUIPart } from "ai";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useCopilotUIStore } from "../../../store";
+import { CopilotChatActionsProvider } from "../../CopilotChatActionsProvider/CopilotChatActionsProvider";
 import {
   ExpertChangeCard,
   ExpertChangeGroup,
@@ -14,6 +15,8 @@ import { ToolResult } from "../ToolResult";
 vi.mock("../../../tools/GenericTool/GenericTool", () => ({
   GenericTool: () => <div data-testid="generic-tool" />,
 }));
+
+const onSend = vi.fn();
 
 const artifactsFlag = { enabled: false };
 vi.mock("@/services/feature-flags/use-get-flag", () => ({
@@ -36,7 +39,6 @@ describe("expert change cards", () => {
   afterEach(() => {
     artifactsFlag.enabled = false;
     useCopilotUIStore.getState().resetArtifactPanel();
-    useCopilotUIStore.getState().setInitialPrompt(null);
   });
 
   it("shows who the proposed expert is and nothing else", () => {
@@ -391,22 +393,27 @@ describe("ExpertChangeGroup", () => {
 });
 
 describe("expert approval", () => {
-  function prompt(): string | null {
-    return useCopilotUIStore.getState().initialPrompt;
+  beforeEach(() => {
+    onSend.mockClear();
+  });
+
+  function renderGroup(
+    parts: ToolUIPart[],
+    props?: { isCurrentlyStreaming?: boolean; readOnly?: boolean },
+  ) {
+    return render(
+      <CopilotChatActionsProvider onSend={onSend}>
+        <ExpertChangeGroup parts={parts} {...props} />
+      </CopilotChatActionsProvider>,
+    );
   }
 
-  it("moves to the next expert on each decision, then drafts all of them", async () => {
+  it("moves to the next expert on each decision, then sends all of them", async () => {
     const user = userEvent.setup();
-    render(
-      <ExpertChangeGroup
-        parts={[proposal("Fiona", "a"), proposal("Bhaskar", "b")]}
-      />,
-    );
+    renderGroup([proposal("Fiona", "a"), proposal("Bhaskar", "b")]);
 
     expect(screen.getByText("Fiona")).toBeDefined();
-    expect(
-      screen.queryByRole("button", { name: "Add decisions to message" }),
-    ).toBeNull();
+    expect(screen.queryByRole("button", { name: "Send decisions" })).toBeNull();
 
     await user.click(screen.getByRole("button", { name: "Approve" }));
     expect(screen.getByText("Bhaskar")).toBeDefined();
@@ -422,23 +429,51 @@ describe("expert approval", () => {
     ).toContain("red");
     expect(screen.queryByRole("button", { name: "Approve" })).toBeNull();
 
-    await user.click(
-      screen.getByRole("button", { name: "Add decisions to message" }),
+    await user.click(screen.getByRole("button", { name: "Send decisions" }));
+    expect(onSend).toHaveBeenCalledTimes(1);
+    expect(onSend).toHaveBeenCalledWith(
+      "Approved: create Fiona (confirmation_id: c-a).\n" +
+        "Not approved: do not create Bhaskar, discard that proposal (confirmation_id: c-b).",
     );
-    expect(prompt()).toContain("Approved: create Fiona");
-    expect(prompt()).toContain("c-a");
-    expect(prompt()).toContain("Not approved: do not create Bhaskar");
-    expect(prompt()).toContain("c-b");
-    expect(screen.getByText("Added to message")).toBeDefined();
+    expect(screen.getByText("Sent")).toBeDefined();
+    expect(screen.queryByRole("button", { name: "Undo decline" })).toBeNull();
+  });
+
+  it("holds the send until the stream has settled", async () => {
+    const user = userEvent.setup();
+    const { rerender } = renderGroup([proposal("Otto", "a")], {
+      isCurrentlyStreaming: true,
+    });
+
+    await user.click(screen.getByRole("button", { name: "Approve" }));
+    expect(screen.queryByRole("button", { name: "Send decisions" })).toBeNull();
+
+    rerender(
+      <CopilotChatActionsProvider onSend={onSend}>
+        <ExpertChangeGroup
+          parts={[proposal("Otto", "a")]}
+          isCurrentlyStreaming={false}
+        />
+      </CopilotChatActionsProvider>,
+    );
+
+    expect(
+      screen.getByRole("button", { name: "Send decisions" }),
+    ).toBeDefined();
+  });
+
+  it("offers no send without a chat actions provider", async () => {
+    const user = userEvent.setup();
+    render(<ExpertChangeGroup parts={[proposal("Otto", "a")]} />);
+
+    await user.click(screen.getByRole("button", { name: "Approve" }));
+
+    expect(screen.queryByRole("button", { name: "Send decisions" })).toBeNull();
   });
 
   it("remembers a decision when paging back", async () => {
     const user = userEvent.setup();
-    render(
-      <ExpertChangeGroup
-        parts={[proposal("Fiona", "a"), proposal("Bhaskar", "b")]}
-      />,
-    );
+    renderGroup([proposal("Fiona", "a"), proposal("Bhaskar", "b")]);
 
     await user.click(screen.getByRole("button", { name: "Approve" }));
     await user.click(screen.getByRole("button", { name: "Previous expert" }));
@@ -453,43 +488,39 @@ describe("expert approval", () => {
     ).not.toContain("emerald");
   });
 
-  it("drafts a single expert straight after its decision", async () => {
+  it("sends a single expert straight after its decision", async () => {
     const user = userEvent.setup();
-    render(<ExpertChangeGroup parts={[proposal("Otto", "a")]} />);
+    renderGroup([proposal("Otto", "a")]);
 
     await user.click(screen.getByRole("button", { name: "Approve" }));
-    await user.click(
-      screen.getByRole("button", { name: "Add decisions to message" }),
-    );
+    await user.click(screen.getByRole("button", { name: "Send decisions" }));
 
-    expect(prompt()).toBe("Approved: create Otto (confirmation_id: c-a).");
+    expect(onSend).toHaveBeenCalledWith(
+      "Approved: create Otto (confirmation_id: c-a).",
+    );
   });
 
-  it("drafts the verb the proposal actually asks for", async () => {
+  it("sends the verb the proposal actually asks for", async () => {
     const user = userEvent.setup();
-    render(
-      <ExpertChangeGroup
-        parts={[
-          expertPart(
-            "output-available",
-            {
-              type: "expert_change_proposed",
-              applied: false,
-              confirmation_id: "c-u",
-              preview: { kind: "update", name: "Otto", role: "Engineer" },
-            },
-            "u",
-          ),
-        ]}
-      />,
-    );
+    renderGroup([
+      expertPart(
+        "output-available",
+        {
+          type: "expert_change_proposed",
+          applied: false,
+          confirmation_id: "c-u",
+          preview: { kind: "update", name: "Otto", role: "Engineer" },
+        },
+        "u",
+      ),
+    ]);
 
     await user.click(screen.getByRole("button", { name: "Approve" }));
-    await user.click(
-      screen.getByRole("button", { name: "Add decisions to message" }),
-    );
+    await user.click(screen.getByRole("button", { name: "Send decisions" }));
 
-    expect(prompt()).toBe("Approved: update Otto (confirmation_id: c-u).");
+    expect(onSend).toHaveBeenCalledWith(
+      "Approved: update Otto (confirmation_id: c-u).",
+    );
   });
 
   it("offers no decision once applied or on a read-only transcript", () => {

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/ExpertCards.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/ExpertCards.test.tsx
@@ -1,7 +1,13 @@
-import { cleanup, render, screen } from "@/tests/integrations/test-utils";
+import {
+  cleanup,
+  render,
+  screen,
+  waitFor,
+} from "@/tests/integrations/test-utils";
 import userEvent from "@testing-library/user-event";
 import type { ToolUIPart } from "ai";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { toast } from "@/components/molecules/Toast/use-toast";
 import { useCopilotUIStore } from "../../../store";
 import { CopilotChatActionsProvider } from "../../CopilotChatActionsProvider/CopilotChatActionsProvider";
 import {
@@ -11,6 +17,11 @@ import {
 } from "../ExpertCards";
 import type { ChainRow } from "../helpers";
 import { ToolResult } from "../ToolResult";
+
+vi.mock("@/components/molecules/Toast/use-toast", () => ({
+  toast: vi.fn(),
+  useToast: () => ({ toast: vi.fn(), dismiss: vi.fn() }),
+}));
 
 vi.mock("../../../tools/GenericTool/GenericTool", () => ({
   GenericTool: () => <div data-testid="generic-tool" />,
@@ -395,6 +406,7 @@ describe("ExpertChangeGroup", () => {
 describe("expert approval", () => {
   beforeEach(() => {
     onSend.mockClear();
+    vi.mocked(toast).mockClear();
   });
 
   function renderGroup(
@@ -498,6 +510,27 @@ describe("expert approval", () => {
     expect(onSend).toHaveBeenCalledWith(
       "Approved: create Otto (confirmation_id: c-a).",
     );
+  });
+
+  it("reports a rejected send and keeps the card marked sent", async () => {
+    const user = userEvent.setup();
+    onSend.mockRejectedValueOnce(new Error("boom"));
+    renderGroup([proposal("Otto", "a")]);
+
+    await user.click(screen.getByRole("button", { name: "Approve" }));
+    await user.click(screen.getByRole("button", { name: "Send decisions" }));
+
+    await waitFor(() =>
+      expect(toast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Couldn't send message",
+          description:
+            "boom — it is still in the thread, use Retry to send it again.",
+          variant: "destructive",
+        }),
+      ),
+    );
+    expect(screen.getByText("Sent")).toBeDefined();
   });
 
   it("sends the verb the proposal actually asks for", async () => {

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/ToolChain.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/ToolChain.test.tsx
@@ -1,10 +1,6 @@
 import userEvent from "@testing-library/user-event";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  cleanup,
-  render as baseRender,
-  screen,
-} from "@/tests/integrations/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { render as baseRender, screen } from "@/tests/integrations/test-utils";
 import { useCopilotUIStore } from "@/app/(platform)/copilot/store";
 import { CopilotChatActionsProvider } from "../../CopilotChatActionsProvider/CopilotChatActionsProvider";
 import type { MessagePart } from "../../ChatMessagesContainer/helpers";
@@ -87,8 +83,6 @@ describe("ToolChain", () => {
   beforeEach(() => {
     onSend.mockClear();
   });
-
-  afterEach(cleanup);
 
   it("renders nothing when no parts map to chain rows", () => {
     const { container } = render(<ToolChain parts={[]} isStreaming={false} />);

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/ToolChain.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/ToolChain.test.tsx
@@ -1,7 +1,6 @@
 import userEvent from "@testing-library/user-event";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  act,
   cleanup,
   render as baseRender,
   screen,
@@ -85,10 +84,11 @@ function getRowToggle(name: RegExp): HTMLElement {
 }
 
 describe("ToolChain", () => {
-  afterEach(() => {
-    cleanup();
-    useCopilotUIStore.setState({ initialPrompt: null, sentMessageCount: 0 });
+  beforeEach(() => {
+    onSend.mockClear();
   });
+
+  afterEach(cleanup);
 
   it("renders nothing when no parts map to chain rows", () => {
     const { container } = render(<ToolChain parts={[]} isStreaming={false} />);
@@ -344,7 +344,7 @@ describe("ToolChain", () => {
     ).toBe("true");
   });
 
-  it("drafts answered questions into the chat input and dismisses on send", async () => {
+  it("sends answered questions and dismisses the card", async () => {
     const user = userEvent.setup();
     const pending: PendingQuestions = {
       dockId: "m1:call-ask_question",
@@ -355,7 +355,7 @@ describe("ToolChain", () => {
     };
 
     render(
-      <CopilotChatActionsProvider onSend={vi.fn()}>
+      <CopilotChatActionsProvider onSend={onSend}>
         <PendingQuestionsContext.Provider value={pending}>
           <ToolChain
             parts={[
@@ -375,9 +375,7 @@ describe("ToolChain", () => {
     expect(screen.getByText("Answer a few questions")).toBeDefined();
     expect(screen.getByText("Which region?")).toBeDefined();
 
-    const submit = screen.getByRole("button", {
-      name: "Add answers to message",
-    });
+    const submit = screen.getByRole("button", { name: "Send answers" });
     expect(submit.hasAttribute("disabled")).toBe(true);
 
     await user.type(
@@ -388,12 +386,10 @@ describe("ToolChain", () => {
 
     await user.click(submit);
 
-    expect(useCopilotUIStore.getState().initialPrompt).toBe(
+    expect(onSend).toHaveBeenCalledTimes(1);
+    expect(onSend).toHaveBeenCalledWith(
       "**Here are my answers:**\n\n> Which region?\n\nWestern Europe\n\nPlease proceed.",
     );
-
-    act(() => useCopilotUIStore.getState().notifyMessageSent());
-
     expect(screen.queryByText("Answer a few questions")).toBeNull();
   });
 
@@ -414,18 +410,14 @@ describe("ToolChain", () => {
     );
 
     expect(screen.getByText("setup-card-GitHub")).toBeDefined();
-    expect(
-      screen.getByText("Everything's filled in — send it to continue"),
-    ).toBeDefined();
+    expect(screen.getByText("Everything's filled in")).toBeDefined();
 
     const proceed = screen.getByRole("button", { name: "Proceed" });
     expect(proceed.hasAttribute("disabled")).toBe(false);
 
     await user.click(proceed);
 
-    expect(useCopilotUIStore.getState().initialPrompt).toBe(
-      "Connected GitHub. Please continue.",
-    );
+    expect(onSend).toHaveBeenCalledWith("Connected GitHub. Please continue.");
   });
 
   it("disables Proceed until every registered card is ready", () => {
@@ -444,15 +436,15 @@ describe("ToolChain", () => {
     );
 
     expect(
-      screen.getByText("Complete the steps above, then send to continue"),
+      screen.getByText("Complete the steps above to continue"),
     ).toBeDefined();
     expect(
       screen.getByRole("button", { name: "Proceed" }).hasAttribute("disabled"),
     ).toBe(true);
-    expect(useCopilotUIStore.getState().initialPrompt).toBeNull();
+    expect(onSend).not.toHaveBeenCalled();
   });
 
-  it("does not draft anything when ready cards produce no message", async () => {
+  it("sends nothing when ready cards produce no message", async () => {
     const user = userEvent.setup();
     render(
       <ToolChain
@@ -470,15 +462,17 @@ describe("ToolChain", () => {
 
     await user.click(screen.getByRole("button", { name: "Proceed" }));
 
-    expect(useCopilotUIStore.getState().initialPrompt).toBeNull();
+    expect(onSend).not.toHaveBeenCalled();
   });
 });
 
 // ToolChain sends the chain's follow-up turn itself, so it needs the actions
 // provider its production parents always supply.
+const onSend = vi.fn();
+
 function render(ui: React.ReactElement) {
   const { rerender, ...rest } = baseRender(
-    <CopilotChatActionsProvider onSend={vi.fn()}>
+    <CopilotChatActionsProvider onSend={onSend}>
       {ui}
     </CopilotChatActionsProvider>,
   );
@@ -486,7 +480,7 @@ function render(ui: React.ReactElement) {
     ...rest,
     rerender: (next: React.ReactElement) =>
       rerender(
-        <CopilotChatActionsProvider onSend={vi.fn()}>
+        <CopilotChatActionsProvider onSend={onSend}>
           {next}
         </CopilotChatActionsProvider>,
       ),

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/ToolChain.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/ToolChain.test.tsx
@@ -438,6 +438,8 @@ describe("ToolChain", () => {
       expect(toast).toHaveBeenCalledWith(
         expect.objectContaining({
           title: "Couldn't send message",
+          description:
+            "boom — it is still in the thread, use Retry to send it again.",
           variant: "destructive",
         }),
       ),

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/ToolChain.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/ToolChain.test.tsx
@@ -1,12 +1,22 @@
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { render as baseRender, screen } from "@/tests/integrations/test-utils";
+import {
+  render as baseRender,
+  screen,
+  waitFor,
+} from "@/tests/integrations/test-utils";
+import { toast } from "@/components/molecules/Toast/use-toast";
 import { useCopilotUIStore } from "@/app/(platform)/copilot/store";
 import { CopilotChatActionsProvider } from "../../CopilotChatActionsProvider/CopilotChatActionsProvider";
 import type { MessagePart } from "../../ChatMessagesContainer/helpers";
 import type { PendingQuestions } from "../../QuestionDock/helpers";
 import { PendingQuestionsContext } from "../../QuestionDock/PendingQuestionsContext";
 import { ToolChain } from "../ToolChain";
+
+vi.mock("@/components/molecules/Toast/use-toast", () => ({
+  toast: vi.fn(),
+  useToast: () => ({ toast: vi.fn(), dismiss: vi.fn() }),
+}));
 
 vi.mock("../../SetupRequirementsCard/SetupRequirementsCard", async () => {
   const { useContext, useEffect } = await import("react");
@@ -82,6 +92,7 @@ function getRowToggle(name: RegExp): HTMLElement {
 describe("ToolChain", () => {
   beforeEach(() => {
     onSend.mockClear();
+    vi.mocked(toast).mockClear();
   });
 
   afterEach(() => {
@@ -384,6 +395,52 @@ describe("ToolChain", () => {
     expect(onSend).toHaveBeenCalledTimes(1);
     expect(onSend).toHaveBeenCalledWith(
       "**Here are my answers:**\n\n> Which region?\n\nWestern Europe\n\nPlease proceed.",
+    );
+    expect(screen.queryByText("Answer a few questions")).toBeNull();
+  });
+
+  it("reports a rejected send without bringing the card back", async () => {
+    const user = userEvent.setup();
+    onSend.mockRejectedValueOnce(new Error("boom"));
+    const pending: PendingQuestions = {
+      dockId: "m1:call-ask_question",
+      callIds: ["call-ask_question"],
+      questions: [
+        { question: "Which region?", keyword: "region", example: "Europe" },
+      ],
+    };
+
+    render(
+      <CopilotChatActionsProvider onSend={onSend}>
+        <PendingQuestionsContext.Provider value={pending}>
+          <ToolChain
+            parts={[
+              toolPart("ask_question", "output-available", {
+                output: {
+                  type: "agent_builder_clarification_needed",
+                  questions: pending.questions,
+                },
+              }),
+            ]}
+            isStreaming={false}
+          />
+        </PendingQuestionsContext.Provider>
+      </CopilotChatActionsProvider>,
+    );
+
+    await user.type(
+      screen.getByPlaceholderText("e.g. Europe"),
+      "Western Europe",
+    );
+    await user.click(screen.getByRole("button", { name: "Send answers" }));
+
+    await waitFor(() =>
+      expect(toast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: "Couldn't send message",
+          variant: "destructive",
+        }),
+      ),
     );
     expect(screen.queryByText("Answer a few questions")).toBeNull();
   });

--- a/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/ToolChain.test.tsx
+++ b/autogpt_platform/frontend/src/app/(platform)/copilot/components/ToolChain/__tests__/ToolChain.test.tsx
@@ -1,5 +1,5 @@
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { render as baseRender, screen } from "@/tests/integrations/test-utils";
 import { useCopilotUIStore } from "@/app/(platform)/copilot/store";
 import { CopilotChatActionsProvider } from "../../CopilotChatActionsProvider/CopilotChatActionsProvider";
@@ -82,6 +82,12 @@ function getRowToggle(name: RegExp): HTMLElement {
 describe("ToolChain", () => {
   beforeEach(() => {
     onSend.mockClear();
+  });
+
+  afterEach(() => {
+    useCopilotUIStore.setState((state) => ({
+      artifactPanel: { ...state.artifactPanel, isOpen: false },
+    }));
   });
 
   it("renders nothing when no parts map to chain rows", () => {
@@ -237,10 +243,9 @@ describe("ToolChain", () => {
 
   it("auto-expands browser rows while the artifact panel is open", async () => {
     const user = userEvent.setup();
-    const { artifactPanel } = useCopilotUIStore.getState();
-    useCopilotUIStore.setState({
-      artifactPanel: { ...artifactPanel, isOpen: true },
-    });
+    useCopilotUIStore.setState((state) => ({
+      artifactPanel: { ...state.artifactPanel, isOpen: true },
+    }));
 
     render(
       <ToolChain
@@ -260,10 +265,6 @@ describe("ToolChain", () => {
       name: /opened "https:\/\/agpt.co"/i,
     });
     expect(row.getAttribute("aria-expanded")).toBe("true");
-
-    useCopilotUIStore.setState({
-      artifactPanel: { ...artifactPanel, isOpen: false },
-    });
   });
 
   it("surfaces the latest error in the heading and drops the Done step", async () => {


### PR DESCRIPTION
### Why / What / How

**Why:** Nick reported having to press send twice on the clarifying-questions card. Answering it (or hitting Enter on the last answer) only drafted the reply into the composer, then the user still had to press send. The drafted multi-line reply also made the composer sprout a scrollbar. Separately, picking an option left the user pressing Next by hand.

**What:** The questions card now sends its reply as soon as it is complete, through the same chat actions context the chain's auto-send and the legacy question dock already use, and picking an option advances to the next question on its own. The draft-into-composer plumbing is removed.

**How:**
- `ToolChain.handleProceed` builds the combined message of every ready card, fires their `onSent`, and calls `onSend` directly. The `draftedRef` / `sentMessageCount` watcher that waited for the user to press send is gone.
- The questions card's last-step button is now "Send answers"; Enter on the last question routes through the same path.
- A click or tap on an option (`onPick`) records the answer and moves the pager to the next question. Arrow keys still only select, keeping the radiogroup keyboard model. On the last question a click only selects; "Send answers" stays the explicit final step.
- Confirm-only Proceed copy no longer tells the user to send afterwards.

Expert proposal cards (Approve / Decline → send) are intentionally untouched here; they get a larger rework in a follow-up PR.

### Changes 🏗️

- `ToolChain/ToolChain.tsx`: Proceed sends instead of drafting; drop `initialPrompt` / `sentMessageCount` usage.
- `ChainActionCard/QuestionsSection.tsx`: "Send answers" label; `handlePick` advances the pager.
- `ChainActionCard/QuestionAnswerField.tsx`, `QuestionOptionList.tsx`: new `onPick` prop for pointer/tap choices, separate from `onChange` which arrows also fire.
- `ChainActionCard/ChainActionCard.tsx`: comment.
- Tests updated in `ToolChain.test.tsx`, `ChainActionCard.test.tsx`, `QuestionAnswerField.test.tsx`; new tests for click-advances, last-question-stays, arrows-don't-advance.

### Agents and large language models used

Claude Code with Claude Fable 5.1 (planning and review) and Claude Opus 5 (implementation).

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `pnpm exec vitest run` on ToolChain + ChainActionCard — 23 files pass
  - [x] `pnpm exec tsc --noEmit` and eslint on changed files clean
  - [ ] Manual: ask copilot something that triggers clarifying questions, answer the last one with Enter → message goes out with no composer step
  - [ ] Manual: question with options → tap one → next question shows, its field focused
  - [ ] Manual: last question with options → tap one → stays, send button enabled