### PR TITLE
docs(frontend): use available matcher in testing guide

### DIFF
--- a/autogpt_platform/frontend/src/tests/AGENTS.md
+++ b/autogpt_platform/frontend/src/tests/AGENTS.md
@@ -109,7 +109,7 @@ test("shows error when submission fails", async () => {
 ```tsx
 // Example: Test component renders correctly
 render(<AgentCard title="My Agent" />);
-expect(screen.getByText("My Agent")).toBeInTheDocument();
+expect(screen.getByText("My Agent")).toBeDefined();
 ```
 
 ### ✅ Storybook Tests (Visual)


### PR DESCRIPTION
### Why / What / How

The frontend testing guide recommends `toBeInTheDocument()`, but the frontend does not declare or register `@testing-library/jest-dom`. Copying the documented example therefore throws `Invalid Chai property: toBeInTheDocument` instead of producing a valid assertion.

This updates the example to `toBeDefined()`, matching the existing Vitest convention used throughout the frontend. `screen.getByText()` already throws when the element is absent, so the example still verifies that the rendered element exists without adding a new dependency or global matcher setup.

Fixes #14507.

### Changes 🏗️

- Replace the unavailable `toBeInTheDocument()` matcher in `src/tests/AGENTS.md` with the suite's existing `toBeDefined()` convention.
- No runtime, dependency, lockfile, or test configuration changes.

### Agents and large language models used

- pi coding agent with GPT-5.6-sol

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] `pnpm format`
  - [x] `pnpm lint` (passes; existing `no-img-element` and Tailwind ambiguity warnings remain)
  - [x] `pnpm types`
  - [x] `LANG=en_US.UTF-8 LC_ALL=en_US.UTF-8 pnpm test:unit` — 6,956 passed
  - [x] Confirmed `@testing-library/jest-dom` is absent from direct dependencies and Vitest setup
  - [x] Confirmed no competing PR references #14507 or implements this matcher correction

#### For configuration changes:

- [x] N/A — no configuration changes
